### PR TITLE
Add example instance to trigger definitions.json.zip generation

### DIFF
--- a/input/fsh/instances/ExampleQermidPacemakersPrimoFollowUpT1.fsh
+++ b/input/fsh/instances/ExampleQermidPacemakersPrimoFollowUpT1.fsh
@@ -1,0 +1,12 @@
+Instance: ExampleQermidPacemakersPrimoFollowUpT1
+InstanceOf: pacemakers-primo-follow-up-t1
+Title: "Example QERMID Pacemakers Primo Follow-up T1"
+Description: "Illustrative example of a QERMID Pacemakers Primo Follow-up T1 record. Field values are placeholders."
+Usage: #example
+
+* TX_REGN_CD = "EXAMPLE-PMK-T1-001"
+* TX_PAT_LAST_NAM = "Doe"
+* TX_PAT_FIRST_NAM = "John"
+* D_PAT_DOB = "1955-04-12"
+* CD_PAT_SEX = "M"
+* D_FLLWUP = "2026-03-15"


### PR DESCRIPTION
## Summary

QERMID's published IG was missing `definitions.json.zip` (and the matching `.xml.zip`, `.ttl.zip`, `examples.*.zip` artifacts) that other IGs produce. Root cause is in [`PublisherGenerator.generateZips()`](https://github.com/HL7/fhir-ig-publisher/blob/master/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java#L4052):

```java
if (generateExampleZip(Manager.FhirFormat.JSON)) {
  generateDefinitions(Manager.FhirFormat.JSON, df.getCanonicalPath());
}
```

`generateExampleZip()` returns `false` when the IG has zero example resources, which short-circuits `generateDefinitions()` for all three formats. QERMID had no examples, so the download bundle was never built.

This adds one minimal example for `pacemakers-primo-follow-up-t1` (chosen because it has zero `1..1` fields, so no required-ValueSet codes need to be valid).

## Test plan

- [x] `sushi .` succeeds (1 instance, 0 errors)
- [x] Local full build with IG Publisher 2.2.7 produces `output/definitions.json.zip` (1.0 MB), `definitions.xml.zip`, `definitions.ttl.zip`, `examples.json.zip`, etc.
- [ ] After merge, CI `Build IG` workflow publishes the new artifacts to https://axelv.github.io/qermid/

🤖 Generated with [Claude Code](https://claude.com/claude-code)