### PR TITLE
Add Downloads page exposing IG artifacts

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,0 +1,15 @@
+### Downloads
+
+This IG ships its conformance resources (logical models, code systems, value sets) as a FHIR NPM package. To use the resources locally with the official FHIR validator (or any tool that reads the FHIR package format), install the package:
+
+```
+fhir install be.healthdata.qermid 0.1.0
+```
+
+The full package archive can also be downloaded directly:
+
+- [FHIR NPM package (.tgz)](package.tgz)
+- [JSON definitions](definitions.json.zip)
+- [XML definitions](definitions.xml.zip)
+- [TTL definitions](definitions.ttl.zip)
+- FSH source — see the [project repository](https://github.com/axelv/qermid)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,12 +24,15 @@ pages:
     title: Registers
   codelists.md:
     title: Code Lists
+  downloads.md:
+    title: Downloads
 
 menu:
   Home: index.html
   Registers: registers.html
   Code Lists: codelists.html
   Artifacts: artifacts.html
+  Downloads: downloads.html
 
 parameters:
   apply-jurisdiction: true


### PR DESCRIPTION
## Summary

Adds a top-level **Downloads** tab to the IG, mirroring how BCR exposes its artifacts. The page links to:

- `package.tgz` — FHIR NPM package
- `definitions.json.zip` / `.xml.zip` / `.ttl.zip` — conformance resource bundles

**Depends on #11** — without that PR, the IG Publisher doesn't emit the `definitions.*.zip` artifacts (it gates them on having at least one example), so several links here would 404. Merge #11 first.

## Test plan

- [x] Local build (IG Publisher 2.2.7) produces `output/downloads.html`
- [x] Top menu shows: Home, Registers, Code Lists, Artifacts, **Downloads**
- [x] All four artifact links resolve to files in `output/`
- [ ] After merge, https://axelv.github.io/qermid/downloads.html is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)